### PR TITLE
Fix PathJoin arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ def generate_launch_description():
         Node(name='does_machines',
              package='donatello',
              executable='donatello_node',
-             parameters=[PathJoinSubstitution(FindPackageShare('donatello'), 'config', 'params.yaml')]),
+             parameters=[PathJoinSubstitution([FindPackageShare('donatello'), 'config', 'params.yaml'])]),
     ])
 ```
 
@@ -180,7 +180,7 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     robot_description = ParameterValue(
-        Command(['xacro ', PathJoinSubstitution(FindPackageShare('urdf_tutorial'), 'urdf', '01-myfirst.urdf')]),
+        Command(['xacro ', PathJoinSubstitution([FindPackageShare('urdf_tutorial'), 'urdf', '01-myfirst.urdf'])]),
         value_type=str)
 
     return LaunchDescription([
@@ -379,7 +379,7 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     file_parameters = ParameterFile(
-        param_file=PathJoinSubstitution(FindPackageShare('donatello'), 'config', 'sub_params.yaml'),
+        param_file=PathJoinSubstitution([FindPackageShare('donatello'), 'config', 'sub_params.yaml']),
         allow_substs=True
     )
 
@@ -420,7 +420,7 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     return LaunchDescription([
-        IncludeLaunchDescription(PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '05-arg.launch.py'),
+        IncludeLaunchDescription(PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '05-arg.launch.py']),
                                  launch_arguments={'pizza_type': 'peppers'}.items()),
     ])
 ```
@@ -462,11 +462,11 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('use_number_one', default_value='True'),
         IncludeLaunchDescription(
-            PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '01-single.launch.py'),
+            PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '01-single.launch.py']),
             condition=IfCondition(LaunchConfiguration('use_number_one')),
         ),
         IncludeLaunchDescription(
-            PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '02-param.launch.py'),
+            PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '02-param.launch.py']),
             condition=UnlessCondition(LaunchConfiguration('use_number_one')),
         ),
     ])
@@ -507,11 +507,11 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    dynamic_param_path = PathJoinSubstitution(
+    dynamic_param_path = PathJoinSubstitution([
         FindPackageShare('donatello'),
         'config',
         [LaunchConfiguration('config'), '.yaml']
-    )
+    ])
 
     return LaunchDescription([
         DeclareLaunchArgument('config', default_value='params'),

--- a/donatello/launch/03-params.launch.py
+++ b/donatello/launch/03-params.launch.py
@@ -9,5 +9,5 @@ def generate_launch_description():
         Node(name='does_machines',
              package='donatello',
              executable='donatello_node',
-             parameters=[PathJoinSubstitution(FindPackageShare('donatello'), 'config', 'params.yaml')]),
+             parameters=[PathJoinSubstitution([FindPackageShare('donatello'), 'config', 'params.yaml'])]),
     ])

--- a/donatello/launch/04-command-params.launch.py
+++ b/donatello/launch/04-command-params.launch.py
@@ -7,7 +7,7 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     robot_description = ParameterValue(
-        Command(['xacro ', PathJoinSubstitution(FindPackageShare('urdf_tutorial'), 'urdf', '01-myfirst.urdf')]),
+        Command(['xacro ', PathJoinSubstitution([FindPackageShare('urdf_tutorial'), 'urdf', '01-myfirst.urdf'])]),
         value_type=str)
 
     return LaunchDescription([

--- a/donatello/launch/06c-substitutions.launch.py
+++ b/donatello/launch/06c-substitutions.launch.py
@@ -8,7 +8,7 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     file_parameters = ParameterFile(
-        param_file=PathJoinSubstitution(FindPackageShare('donatello'), 'config', 'sub_params.yaml'),
+        param_file=PathJoinSubstitution([FindPackageShare('donatello'), 'config', 'sub_params.yaml']),
         allow_substs=True
     )
 

--- a/donatello/launch/07-inclusive.launch.py
+++ b/donatello/launch/07-inclusive.launch.py
@@ -6,6 +6,6 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     return LaunchDescription([
-        IncludeLaunchDescription(PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '05-arg.launch.py'),
+        IncludeLaunchDescription(PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '05-arg.launch.py']),
                                  launch_arguments={'pizza_type': 'peppers'}.items()),
     ])

--- a/donatello/launch/08-conditional.launch.py
+++ b/donatello/launch/08-conditional.launch.py
@@ -9,11 +9,11 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('use_number_one', default_value='True'),
         IncludeLaunchDescription(
-            PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '01-single.launch.py'),
+            PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '01-single.launch.py']),
             condition=IfCondition(LaunchConfiguration('use_number_one')),
         ),
         IncludeLaunchDescription(
-            PathJoinSubstitution(FindPackageShare('donatello'), 'launch', '02-param.launch.py'),
+            PathJoinSubstitution([FindPackageShare('donatello'), 'launch', '02-param.launch.py']),
             condition=UnlessCondition(LaunchConfiguration('use_number_one')),
         ),
     ])

--- a/donatello/launch/09-dynamic-filename.launch.py
+++ b/donatello/launch/09-dynamic-filename.launch.py
@@ -6,11 +6,11 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    dynamic_param_path = PathJoinSubstitution(
+    dynamic_param_path = PathJoinSubstitution([
         FindPackageShare('donatello'),
         'config',
         [LaunchConfiguration('config'), '.yaml']
-    )
+    ])
 
     return LaunchDescription([
         DeclareLaunchArgument('config', default_value='params'),


### PR DESCRIPTION
Current examples result in the following error:

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [py]:
 - TypeError: PathJoinSubstitution.__init__() takes 2 positional arguments but 4 were given
 - InvalidFrontendLaunchFileError: The launch file may have a syntax error, or its format is unknown
```

I swear this syntax worked in some previous version of ROS, but [the commit history](https://github.com/ros2/launch/commits/rolling/launch/launch/substitutions/path_join_substitution.py) leads me to believe this was just a mistake on my part. 